### PR TITLE
Add ability to send or not send report based on build status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # "Github Custom Notification Context SCM Behaviour" Jenkins plugin
 
-This plugin allows defining custom context labels for GitHub build status notifications. This was implemented by Github Branch Source trait.
+This plugin allows defining custom context labels for GitHub build status notifications and optionally select only subset of statuses to report. This was implemented by Github Branch Source trait.
 
 ## How to use this plugin
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <artifactId>github-scm-trait-notification-context</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.3</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.73.3</jenkins.version>

--- a/src/main/resources/org/jenkinsci/plugins/githubScmTraitNotificationContext/NotificationContextTrait/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/githubScmTraitNotificationContext/NotificationContextTrait/config.jelly
@@ -6,4 +6,19 @@
     <f:entry title="Label" field="contextLabel">
         <f:textbox default="continuous-integration/jenkins"/>
     </f:entry>
+    <f:entry title="Report SUCCESS build result?" field="reportSuccess">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Report UNSTABLE build result?" field="reportUnstable">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Report FAILURE build result?" field="reportFailure">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Report NOT_BUILT build result?" field="reportNotBuilt">
+        <f:checkbox />
+    </f:entry>
+    <f:entry title="Report ABORTED build result?" field="reportAborted">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
As in some build systems, some statuses are used for builds that were not (re)scheduled for capacity reasons (in our system it is "Unstable") and github interprets unstable as "tests failed", this generates lot of false alarms.

In general, it could be useful to report only some statuses.

This PR extends the plugin so additionally for all statuses it can be configured to send or not send the appropriate notification.