### PR TITLE
Migrate plugin doc to Github

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <name>GitHub Custom Notification Context SCM Behaviour</name>
     <description>A trait which allows the setting of a custom context in the GitHub status notifications</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Custom+Notification+Context+SCM+Behaviour</url>
+    <url>https://github.com/jenkinsci/github-scm-trait-notification-context-plugin</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
### Overview

Update this plugin's doc to Github.

https://www.jenkins.io/doc/developer/publishing/wiki-page/
https://www.jenkins.io/doc/developer/publishing/documentation/

Should have done this in https://github.com/jenkinsci/github-scm-trait-notification-context-plugin/pull/8, but missed it.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
